### PR TITLE
support suffixed golang docker images

### DIFF
--- a/latest_go_ensurer/main_test.go
+++ b/latest_go_ensurer/main_test.go
@@ -48,6 +48,16 @@ func TestDockerfileFromUpdate(t *testing.T) {
 			"1.1",
 			"FROM golang:1.1",
 		},
+		{
+			"from golang:1.13.1-alpine",
+			"1.13.3",
+			"from golang:1.13.3-alpine",
+		},
+		{
+			"from golang:1.-werd",
+			"1.13.3",
+			"from golang:1.13.3",
+		},
 	}
 
 	for i, tc := range testcases {


### PR DESCRIPTION
This supports golang images named things like "golang:1.13.3-alpine".