### PR TITLE
update create-pull-request action to v1

### DIFF
--- a/.github/workflows/ensure_go.yml
+++ b/.github/workflows/ensure_go.yml
@@ -20,7 +20,7 @@ jobs:
       - run: echo "##[set-output name=pr_title;]update to latest Go release ${{ steps.ensure_go.outputs.go_version}}"
         id: pr_title_maker
       - name: Create pull request
-        uses: peter-evans/create-pull-request@v1.7.2
+        uses: peter-evans/create-pull-request@v1
         with:
           title: ${{ steps.pr_title_maker.outputs.pr_title }}
           body: Auto-generated pull request created by the GitHub Actions [create-pull-request](https://github.com/peter-evans/create-pull-request) and [ensure-latest-go](https://github.com/jmhodges/ensure-latest-go). 

--- a/.github/workflows/ensure_go.yml
+++ b/.github/workflows/ensure_go.yml
@@ -20,11 +20,11 @@ jobs:
       - run: echo "##[set-output name=pr_title;]update to latest Go release ${{ steps.ensure_go.outputs.go_version}}"
         id: pr_title_maker
       - name: Create pull request
-        uses: peter-evans/create-pull-request@v1.5.2
-        env:
-          PULL_REQUEST_TITLE: ${{ steps.pr_title_maker.outputs.pr_title }}
-          PULL_REQUEST_BODY: Auto-generated pull request created by the GitHub Actions [create-pull-request](https://github.com/peter-evans/create-pull-request) and [ensure-latest-go](https://github.com/jmhodges/ensure-latest-go). 
-          COMMIT_MESSAGE: ${{ steps.pr_title_maker.outputs.pr_title }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          BRANCH_SUFFIX: none
-          PULL_REQUEST_BRANCH: ensure-latest-go/patch-${{ steps.ensure_go.outputs.go_version }}
+        uses: peter-evans/create-pull-request@v1.7.2
+        with:
+          title: ${{ steps.pr_title_maker.outputs.pr_title }}
+          body: Auto-generated pull request created by the GitHub Actions [create-pull-request](https://github.com/peter-evans/create-pull-request) and [ensure-latest-go](https://github.com/jmhodges/ensure-latest-go). 
+          commit-message: ${{ steps.pr_title_maker.outputs.pr_title }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          branch-suffix: none
+          branch: ensure-latest-go/patch-${{ steps.ensure_go.outputs.go_version }}

--- a/.github/workflows/ensure_go.yml
+++ b/.github/workflows/ensure_go.yml
@@ -28,3 +28,4 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           branch-suffix: none
           branch: ensure-latest-go/patch-${{ steps.ensure_go.outputs.go_version }}
+          base: master

--- a/README.md
+++ b/README.md
@@ -32,14 +32,14 @@ jobs:
       - run: echo "##[set-output name=pr_title;]update to latest Go release ${{ steps.ensure_go.outputs.go_version}}"
         id: pr_title_maker
       - name: Create pull request
-        uses: peter-evans/create-pull-request@v1.5.2
-        env:
-          PULL_REQUEST_TITLE: ${{ steps.pr_title_maker.outputs.pr_title }}
-          PULL_REQUEST_BODY: Auto-generated pull request created by the GitHub Actions [create-pull-request](https://github.com/peter-evans/create-pull-request) and [ensure-latest-go](https://github.com/jmhodges/ensure-latest-go).
-          COMMIT_MESSAGE: ${{ steps.pr_title_maker.outputs.pr_title }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          BRANCH_SUFFIX: none
-          PULL_REQUEST_BRANCH: ensure-latest-go/patch-${{ steps.ensure_go.outputs.go_version }}
+        uses: peter-evans/create-pull-request@v1.7.2
+        with:
+          title: ${{ steps.pr_title_maker.outputs.pr_title }}
+          body: Auto-generated pull request created by the GitHub Actions [create-pull-request](https://github.com/peter-evans/create-pull-request) and [ensure-latest-go](https://github.com/jmhodges/ensure-latest-go).
+          commit-message: ${{ steps.pr_title_maker.outputs.pr_title }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          branch-suffix: none
+          branch: ensure-latest-go/patch-${{ steps.ensure_go.outputs.go_version }}
 ```
 
 To enjoy the full benefits with GitHub Actions, you'll need to add a `.github/versions/go` file to your repository with the version of Go you want `actions/setup-go` to use. Then, modify your `actions/setup-go` job to include:

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ jobs:
       - run: echo "##[set-output name=pr_title;]update to latest Go release ${{ steps.ensure_go.outputs.go_version}}"
         id: pr_title_maker
       - name: Create pull request
-        uses: peter-evans/create-pull-request@v1.7.2
+        uses: peter-evans/create-pull-request@v1
         with:
           title: ${{ steps.pr_title_maker.outputs.pr_title }}
           body: Auto-generated pull request created by the GitHub Actions [create-pull-request](https://github.com/peter-evans/create-pull-request) and [ensure-latest-go](https://github.com/jmhodges/ensure-latest-go).


### PR DESCRIPTION
Hope you don't mind if I send this pull request to update create-pull-request action. If you want to keep using the same version that's fine! I won't be offended 😄 
There are a couple of good reasons to update though:
- From version 1.7.x I converted the action to a container-less style of action. This makes it multi-platform and able to run on all three VMs (Linux, macOS, Windows).
- It's faster than the container action because GitHub Actions just clones the action code and executes it

This update executed successfully here: https://github.com/peter-evans/ensure-latest-go/commit/bbe83a7260af87e98a1923a508c66ff1f5bc2769/checks?check_suite_id=305111805
And produced this PR: https://github.com/peter-evans/ensure-latest-go/pull/3

By the way, I added an example for ensure-latest-go action to the examples page here:
https://github.com/peter-evans/create-pull-request/blob/master/examples.md#keep-go-up-to-date
Feel free to send a PR to update it.