### PR TITLE
update create-pull-request action to v2

### DIFF
--- a/.github/workflows/ensure_go.yml
+++ b/.github/workflows/ensure_go.yml
@@ -20,12 +20,11 @@ jobs:
       - run: echo "##[set-output name=pr_title;]update to latest Go release ${{ steps.ensure_go.outputs.go_version}}"
         id: pr_title_maker
       - name: Create pull request
-        uses: peter-evans/create-pull-request@v1
+        uses: peter-evans/create-pull-request@v2
         with:
           title: ${{ steps.pr_title_maker.outputs.pr_title }}
           body: Auto-generated pull request created by the GitHub Actions [create-pull-request](https://github.com/peter-evans/create-pull-request) and [ensure-latest-go](https://github.com/jmhodges/ensure-latest-go). 
           commit-message: ${{ steps.pr_title_maker.outputs.pr_title }}
           token: ${{ secrets.GITHUB_TOKEN }}
-          branch-suffix: none
           branch: ensure-latest-go/patch-${{ steps.ensure_go.outputs.go_version }}
           base: master

--- a/README.md
+++ b/README.md
@@ -32,13 +32,12 @@ jobs:
       - run: echo "##[set-output name=pr_title;]update to latest Go release ${{ steps.ensure_go.outputs.go_version}}"
         id: pr_title_maker
       - name: Create pull request
-        uses: peter-evans/create-pull-request@v1
+        uses: peter-evans/create-pull-request@v2
         with:
           title: ${{ steps.pr_title_maker.outputs.pr_title }}
           body: Auto-generated pull request created by the GitHub Actions [create-pull-request](https://github.com/peter-evans/create-pull-request) and [ensure-latest-go](https://github.com/jmhodges/ensure-latest-go).
           commit-message: ${{ steps.pr_title_maker.outputs.pr_title }}
           token: ${{ secrets.GITHUB_TOKEN }}
-          branch-suffix: none
           branch: ensure-latest-go/patch-${{ steps.ensure_go.outputs.go_version }}
 ```
 


### PR DESCRIPTION
- Updates create-pull-request to [`v2`](https://github.com/peter-evans/create-pull-request/releases/tag/v2.0.0)
- By default commits are made as the GitHub Actions bot user. You can override with the new `author` and `committer` inputs.